### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/jsinger67/scnr2/security/code-scanning/1](https://github.com/jsinger67/scnr2/security/code-scanning/1)

To fix this issue, we need to explicitly set the `permissions` key for the workflow or for the individual job to restrict the `GITHUB_TOKEN` permissions to only what is needed. For this workflow, because it just checks out code, builds, and runs tests, it only needs read access to repository contents. You can set this at the workflow root, which will apply the restriction to all jobs unless overridden, or at the job level. The best practice is to set `permissions: contents: read` at the root of the workflow, above the `jobs:` block, ensuring all jobs inherit the minimal permissions required. This change should be made in `.github/workflows/rust.yml` by inserting the block after the `name:` and before `on:`.

No additional imports, methods, or external libraries are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
